### PR TITLE
Fix server README and start script

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -20,7 +20,7 @@ Node.js + Express + MongoDB (Mongoose) backend for the Blood Donation System.
 
 4. Start backend:
    ```bash
-   npm run dev
+   npm start
    ```
 
 API runs at http://localhost:5000/api

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a `start` script to run `node app.js`
- update backend README to use `npm start`

## Testing
- `npm test` in `server` (fails: no tests specified)
- `npm test -- -w 1` in `client` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_68405d73cc90832e880ca654146c7068